### PR TITLE
fix react preset in config-eslint package

### DIFF
--- a/packages/config-eslint/base..js
+++ b/packages/config-eslint/base..js
@@ -30,6 +30,7 @@ export default [
       parserOptions: { project: "./tsconfig.json" },
     },
     rules: {
+      ...react.configs["recommended-type-checked"].rules,
       "@eslint-react/prefer-shorthand-boolean": "error",
       "@eslint-react/naming-convention/filename-extension": "error",
     },

--- a/packages/react-window-splitter/src/ReactWindowSplitter.tsx
+++ b/packages/react-window-splitter/src/ReactWindowSplitter.tsx
@@ -1726,6 +1726,7 @@ export const PanelGroup = React.forwardRef<HTMLDivElement, PanelGroupProps>(
     const [hasPreRendered, setHasPreRendered] = useState(false);
     const initialMap = useRef<Record<string, Item>>({});
     const indexedChildren = useIndexedChildren(
+      // eslint-disable-next-line @eslint-react/no-children-to-array
       flattenChildren(React.Children.toArray(children))
     );
 


### PR DESCRIPTION
It appears that the rules from `react.configs["recommended-type-checked"]` preset in config-eslint are not actually enabled. This PR addresses this issue. Please ignore the PR if this was intentional.