### PR TITLE
Fix panel not expanding to take up width with a default collapsed panel

### DIFF
--- a/packages/react-window-splitter/src/ReactWindowSplitter.stories.tsx
+++ b/packages/react-window-splitter/src/ReactWindowSplitter.stories.tsx
@@ -170,6 +170,33 @@ export function VerticalLayout({
   );
 }
 
+export function VerticalLayout2({
+  handle,
+}: {
+  handle?: React.Ref<PanelGroupHandle>;
+}) {
+  return (
+    <StyledPanelGroup
+      handle={handle}
+      orientation="vertical"
+      style={{ height: 322 }}
+    >
+      <StyledPanel default="200px" min="200px">
+        top
+      </StyledPanel>
+      <StyledResizer />
+      <StyledPanel
+        min="200px"
+        collapsedSize="60px"
+        defaultCollapsed
+        collapsible
+      >
+        middle
+      </StyledPanel>
+    </StyledPanelGroup>
+  );
+}
+
 export function NestedGroups() {
   return (
     <PanelGroup

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -812,11 +812,28 @@ export function buildTemplate(context: GroupMachineContextValue) {
         } else if (item.collapsible && item.collapsed) {
           return formatUnit(item.collapsedSize);
         } else if (item.default) {
-          return formatUnit(item.default);
-        }
+          const siblingHasFill = context.items.some(
+            (i) =>
+              isPanelData(i) &&
+              i.id !== item.id &&
+              !i.collapsed &&
+              (i.max === "1fr" ||
+                (i.max.type === "percent" && i.max.value.eq(100)))
+          );
 
-        const max = item.max === "1fr" ? "1fr" : formatUnit(item.max);
-        return `minmax(${min}, ${max})`;
+          // If a sibling has a fill, this item doesn't need to expand
+          // So we can just use the default value
+          if (siblingHasFill) {
+            return formatUnit(item.default);
+          }
+
+          // Use 1fr so that panel fills ths space if needed
+          const max = item.max === "1fr" ? "1fr" : formatUnit(item.max);
+          return `minmax(${formatUnit(item.default)}, ${max})`;
+        } else {
+          const max = item.max === "1fr" ? "1fr" : formatUnit(item.max);
+          return `minmax(${min}, ${max})`;
+        }
       }
 
       return formatUnit(item.size);

--- a/packages/state/src/machine.test.ts
+++ b/packages/state/src/machine.test.ts
@@ -469,7 +469,7 @@ describe("constraints", () => {
     }).start();
 
     expect(getTemplate(actor)).toMatchInlineSnapshot(
-      `"minmax(0px, 90%) 10px 30%"`
+      `"minmax(0px, 90%) 10px minmax(30%, 1fr)"`
     );
     initializeSizes(actor, { width: 500, height: 200 });
 
@@ -477,6 +477,29 @@ describe("constraints", () => {
       dragHandle(actor, { id: "resizer-1", delta: 500 });
       expect(getTemplate(actor)).toMatchInlineSnapshot(`"450px 10px 40px"`);
     });
+  });
+
+  test("supports 1 panel being collapsed with another panel expanding to fill", () => {
+    const actor = createActor(groupMachine, {
+      input: {
+        groupId: "group",
+        initialItems: [
+          initializePanel({ id: "panel-1", default: "200px", min: "200px" }),
+          initializePanelHandleData({ id: "resizer-1", size: "10px" }),
+          initializePanel({
+            id: "panel-2",
+            min: "200px",
+            collapsible: true,
+            collapsedSize: "60px",
+            defaultCollapsed: true,
+          }),
+        ],
+      },
+    }).start();
+
+    expect(getTemplate(actor)).toMatchInlineSnapshot(
+      `"minmax(200px, 1fr) 10px 60px"`
+    );
   });
 
   test("panel can have a min", () => {
@@ -732,7 +755,7 @@ describe("collapsible panel", () => {
     capturePixelValues(actor, () => {
       expect(getTemplate(actor)).toBe("490px 10px 0px");
 
-      // Stays oollapsed in the buffer
+      // Stays collapsed in the buffer
       dragHandle(actor, { id: "resizer-1", delta: -30 });
       expect(getTemplate(actor)).toBe("490px 10px 0px");
 


### PR DESCRIPTION
Previously in this case the panels wouldn't fill the space. Now a default panel might expand if there is no other panel that does