### PR TITLE
Fix incorrect size comparison between new and current size

### DIFF
--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -2257,7 +2257,7 @@ export function groupMachine(
             panel,
             getUnitPixelValue(context, parseUnit(event.size))
           );
-          const isBigger = newSize > current;
+          const isBigger = newSize.gt(current);
           const delta = isBigger
             ? newSize.minus(current)
             : current.minus(newSize);


### PR DESCRIPTION
This fixes the issue described in https://github.com/hipstersmoothie/window-splitter/issues/74
The size comparison should use the gt() method from Big.js instead of the plain > operator, which caused incorrect clamping behavior.