### PR TITLE
fix: tolerate sub-pixel overflow

### DIFF
--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -1638,7 +1638,7 @@ function handleOverflow(context: GroupMachineContextValue) {
   const totalSize = pixelItems.reduce((acc, i) => acc.add(i), new Big(0));
   const overflow = totalSize.abs().sub(groupSize);
 
-  if (overflow.eq(0) || groupSize.eq(0)) {
+  if (overflow.abs().lt(1) || groupSize.eq(0)) {
     return context;
   }
 


### PR DESCRIPTION
I encountered an issue when opening a panel on smaller screens with browser zoom set to, say, 90% or 110% - it would open for a brief second and then auto-collapse. I've found out that due to the browser zoom, calculation of space needed for the panel would overflow by sub-pixel values (like trying to render a 1000.0003px panel in a 1000px space) - it was causing the panel to collapse right after opening.

The fix ignores differences smaller than a single pixel, since fractional pixels aren't visible to the user anyway.