### PR TITLE
Also skip onUpdate on transition into togglingCollapse to remove frame-0 hitch

### DIFF
--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -2031,6 +2031,7 @@ export function groupMachine(
     }
 
     // enter
+    let skipOnUpdate = false;
     switch (to) {
       case "idle":
         actions.onAutosave();
@@ -2041,12 +2042,30 @@ export function groupMachine(
       case "togglingCollapse":
         actions.prepare();
         actions.clearLastKnownSize();
+        // Write post-prepare template to DOM instead of routing through React.
+        // `prepare()` converts % to px (same rendered width) — committing
+        // through React fires a Layout pass before the raf loop starts,
+        // producing a visible hitch on frame 0.
+        if (getGroupElement) {
+          const el = getGroupElement();
+          if (el) {
+            const template = buildTemplate(context);
+            if (context.orientation === "horizontal") {
+              el.style.gridTemplateColumns = template;
+            } else {
+              el.style.gridTemplateRows = template;
+            }
+            skipOnUpdate = true;
+          }
+        }
         break;
     }
 
     state.current = to;
 
-    onUpdate?.(context);
+    if (!skipOnUpdate) {
+      onUpdate?.(context);
+    }
   }
 
   function send(event: GroupMachineEvent) {

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -2021,7 +2021,7 @@ export function groupMachine(
     },
   };
 
-  function transition(to: State) {
+  function transition(to: State): boolean {
     // exit
     switch (state.current) {
       case "dragging":
@@ -2045,7 +2045,9 @@ export function groupMachine(
         // Write post-prepare template to DOM instead of routing through React.
         // `prepare()` converts % to px (same rendered width) — committing
         // through React fires a Layout pass before the raf loop starts,
-        // producing a visible hitch on frame 0.
+        // producing a visible hitch on frame 0. Callers propagate the
+        // returned flag into send()'s skipOnUpdate so the trailing onUpdate
+        // there is suppressed too.
         if (getGroupElement) {
           const el = getGroupElement();
           if (el) {
@@ -2066,6 +2068,8 @@ export function groupMachine(
     if (!skipOnUpdate) {
       onUpdate?.(context);
     }
+
+    return skipOnUpdate;
   }
 
   function send(event: GroupMachineEvent) {
@@ -2328,7 +2332,7 @@ export function groupMachine(
             const panel = getPanelWithId(context, event.panelId);
 
             if (!panel.collapsed) {
-              transition("togglingCollapse");
+              if (transition("togglingCollapse")) skipOnUpdate = true;
               abortController.abort();
               animationActor(context, event, send, abortController).then(
                 (output) => {
@@ -2351,7 +2355,7 @@ export function groupMachine(
             const panel = getPanelWithId(context, event.panelId);
 
             if (panel.collapsed) {
-              transition("togglingCollapse");
+              if (transition("togglingCollapse")) skipOnUpdate = true;
               abortController.abort();
               animationActor(context, event, send, abortController).then(
                 (output) => {

--- a/packages/state/src/machine.test.ts
+++ b/packages/state/src/machine.test.ts
@@ -627,6 +627,34 @@ describe("constraints", () => {
       document.body.removeChild(groupEl);
     });
 
+    test("collapsePanel does not fire onUpdate when getGroupElement is provided (frame-0 hitch)", async () => {
+      const groupEl = document.createElement("div");
+      groupEl.style.display = "grid";
+      document.body.appendChild(groupEl);
+
+      let updateCount = 0;
+      const actor = setupCollapsibleActor(groupEl, () => {
+        updateCount++;
+      });
+      registerCollapsibleLayout(actor);
+
+      const updatesBeforeCollapse = updateCount;
+
+      actor.send({ type: "collapsePanel", panelId: "panel-2" });
+
+      expect(actor.state.current).toBe("togglingCollapse");
+      // Neither transition() nor send()'s trailing onUpdate should fire —
+      // otherwise React commits + Layout runs before frame 1 of the animation.
+      expect(updateCount).toBe(updatesBeforeCollapse);
+
+      // DOM template must be written synchronously so the animation actor
+      // starts against pixel-form values.
+      expect(groupEl.style.gridTemplateColumns).toBeTruthy();
+
+      await waitForIdle(actor);
+      document.body.removeChild(groupEl);
+    });
+
     test("onUpdate IS called after animation ends (final sync)", async () => {
       const groupEl = document.createElement("div");
       document.body.appendChild(groupEl);


### PR DESCRIPTION
Frame 0 of the animation still routes through React. `applyDelta` and RO echo both get `skipOnUpdate`, but `transition("togglingCollapse")` doesn't:

```ts
case "togglingCollapse":
  actions.prepare();              // % → px on context.items
  actions.clearLastKnownSize();
  break;
// ...
onUpdate?.(context);              // ← still fires for togglingCollapse
```

`prepare()` rewrites the template (`%` → `px`, same rendered width, different string). The `onUpdate` here forces one React commit + Layout pass before `animationActor` schedules frame 1. On chart-heavy layouts that commit eats 30-60ms, so the first 1-2 raf ticks land late. After that the DOM-only path takes over and it's smooth.

Visible as: slow start, snap to speed. Reproduces on a plain SQL pane too — not descendant reflow.

Suggested — same `skipOnUpdate` treatment `applyDelta` already gets:

```diff
+let skipOnUpdate = false;
 switch (to) {
   case "togglingCollapse":
     actions.prepare();
     actions.clearLastKnownSize();
+    if (getGroupElement) {
+      const el = getGroupElement();
+      if (el) {
+        const template = buildTemplate(context);
+        if (context.orientation === "horizontal") {
+          el.style.gridTemplateColumns = template;
+        } else {
+          el.style.gridTemplateRows = template;
+        }
+        skipOnUpdate = true;
+      }
+    }
     break;
 }
 state.current = to;
-onUpdate?.(context);
+if (!skipOnUpdate) onUpdate?.(context);
```

Safe because `prepare()` doesn't change rendered width, closing `transition("idle")` flushes context to React normally, and the `getGroupElement` guard preserves old behavior when the consumer hasn't opted in.

Confirm in DevTools Performance: `Recalculate Style` + `Layout` currently lands before the first `applyDelta`. With the patch, first tick fires clean.

Separate follow-up (not this PR): `raf(renderFrame)` → `start()` → `nativeRaf(loop)` → next-frame `loop()` → `update()` → `renderFrame` adds ~2 rAFs of click-to-first-motion latency. Minor next to frame 0.

*Generated with [Claude Code](https://claude.com/claude-code) · [Opus 4.7](https://www.anthropic.com/claude/opus)*
